### PR TITLE
Use distroless for docker to reduce vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,19 @@ ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
+# copy the dependencies file to the working directory
+COPY requirements.txt .
+
 # copy the content of the local src directory to the working directory
 COPY src/ .
 
-# Install dependencies.
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Download dependencies as a separate step to take advantage of Docker's caching.
+# Leverage a cache mount to /root/.cache/pip to speed up subsequent builds.
+# Leverage a bind mount to requirements.txt to avoid having to copy them into
+# into this layer.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=requirements.txt,target=requirements.txt \
+    python -m pip install -r requirements.txt
 
 # Using the distroless python3-debian12:nonroot image
 FROM gcr.io/distroless/python3-debian12@sha256:66f3e24fd4906156a7360d2861731d31d3457a02f34fd3c4491f0b710a259988 AS runtime


### PR DESCRIPTION
- Use distroless to reduce vulnerabilities
- Remove non-privileged user code as it is covered as part of distroless non-root tag